### PR TITLE
Feat/auth/implement authentication

### DIFF
--- a/app/channels/application_cable/connection.rb
+++ b/app/channels/application_cable/connection.rb
@@ -1,0 +1,16 @@
+module ApplicationCable
+  class Connection < ActionCable::Connection::Base
+    identified_by :current_user
+
+    def connect
+      set_current_user || reject_unauthorized_connection
+    end
+
+    private
+      def set_current_user
+        if session = Session.find_by(id: cookies.signed[:session_id])
+          self.current_user = session.user
+        end
+      end
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,46 @@
+# app/controllers/admin/users_controller.rb
+class Admin::UsersController < ApplicationController
+  include AdminGate
+
+  def index
+    @users = User.order(:email_address, :first_name, :last_name)
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_users_path, notice: "User created."
+    else
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to admin_users_path, notice: "User updated."
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    User.find(params[:id]).destroy!
+    redirect_to admin_users_path, notice: "User deleted."
+  end
+
+  private
+
+  def user_params
+    params.require(:user).permit(:email_address, :email, :first_name, :last_name, :password, :password_confirmation)
+      .delete_if { |_, v| v.blank? } # allow blank password on update
+  end
+end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  include Authentication
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,15 @@
+# app/controllers/application_controller.rb
 class ApplicationController < ActionController::Base
   include Authentication
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern
+
+  helper_method :current_user, :authenticated?
+
+  def current_user
+    Current.user            # Authentication concern populates Current.session → Current.user
+  end
+
+  def authenticated?
+    Current.user.present?
+  end
 end

--- a/app/controllers/concerns/admin_gate.rb
+++ b/app/controllers/concerns/admin_gate.rb
@@ -1,0 +1,21 @@
+# app/controllers/concerns/admin_gate.rb
+module AdminGate
+  extend ActiveSupport::Concern
+  included { before_action :require_admin! }
+
+  private
+  def require_admin!
+    unless authenticated?
+      session[:return_to] = request.fullpath
+      redirect_to(sign_in_path, alert: "Please sign in") and return
+    end
+
+    user_email = current_user.email_address.to_s.strip.downcase
+    allowed    = ENV.fetch("ADMIN_EMAILS", "").split(",").map { _1.strip.downcase }.reject(&:blank?)
+
+    Rails.logger.info("[AdminGate] user=#{user_email} allowed=#{allowed.inspect}")
+
+    return if allowed.include?(user_email)
+    head :forbidden
+  end
+end

--- a/app/controllers/concerns/authentication.rb
+++ b/app/controllers/concerns/authentication.rb
@@ -1,0 +1,52 @@
+module Authentication
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_authentication
+    helper_method :authenticated?
+  end
+
+  class_methods do
+    def allow_unauthenticated_access(**options)
+      skip_before_action :require_authentication, **options
+    end
+  end
+
+  private
+    def authenticated?
+      resume_session
+    end
+
+    def require_authentication
+      resume_session || request_authentication
+    end
+
+    def resume_session
+      Current.session ||= find_session_by_cookie
+    end
+
+    def find_session_by_cookie
+      Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id]
+    end
+
+    def request_authentication
+      session[:return_to_after_authenticating] = request.url
+      redirect_to new_session_path
+    end
+
+    def after_authentication_url
+      session.delete(:return_to_after_authenticating) || root_url
+    end
+
+    def start_new_session_for(user)
+      user.sessions.create!(user_agent: request.user_agent, ip_address: request.remote_ip).tap do |session|
+        Current.session = session
+        cookies.signed.permanent[:session_id] = { value: session.id, httponly: true, same_site: :lax }
+      end
+    end
+
+    def terminate_session
+      Current.session.destroy
+      cookies.delete(:session_id)
+    end
+end

--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -1,0 +1,33 @@
+class PasswordsController < ApplicationController
+  allow_unauthenticated_access
+  before_action :set_user_by_token, only: %i[ edit update ]
+
+  def new
+  end
+
+  def create
+    if user = User.find_by(email_address: params[:email_address])
+      PasswordsMailer.reset(user).deliver_later
+    end
+
+    redirect_to new_session_path, notice: "Password reset instructions sent (if user with that email address exists)."
+  end
+
+  def edit
+  end
+
+  def update
+    if @user.update(params.permit(:password, :password_confirmation))
+      redirect_to new_session_path, notice: "Password has been reset."
+    else
+      redirect_to edit_password_path(params[:token]), alert: "Passwords did not match."
+    end
+  end
+
+  private
+    def set_user_by_token
+      @user = User.find_by_password_reset_token!(params[:token])
+    rescue ActiveSupport::MessageVerifier::InvalidSignature
+      redirect_to new_password_path, alert: "Password reset link is invalid or has expired."
+    end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,21 @@
+class SessionsController < ApplicationController
+  allow_unauthenticated_access only: %i[ new create ]
+  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
+
+  def new
+  end
+
+  def create
+    if user = User.authenticate_by(params.permit(:email_address, :password))
+      start_new_session_for user
+      redirect_to after_authentication_url
+    else
+      redirect_to new_session_path, alert: "Try another email address or password."
+    end
+  end
+
+  def destroy
+    terminate_session
+    redirect_to new_session_path
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,21 +1,36 @@
+# app/controllers/sessions_controller.rb
 class SessionsController < ApplicationController
-  allow_unauthenticated_access only: %i[ new create ]
-  rate_limit to: 10, within: 3.minutes, only: :create, with: -> { redirect_to new_session_url, alert: "Try again later." }
+  skip_before_action :require_authentication, only: %i[new create]
 
-  def new
-  end
+  def new; end
 
   def create
-    if user = User.authenticate_by(params.permit(:email_address, :password))
-      start_new_session_for user
-      redirect_to after_authentication_url
+    email = params[:email_address].to_s.downcase
+    user  = User.find_by(email_address: email)
+
+    if user&.authenticate(params[:password])
+      # end any existing DB session for this browser
+      Current.session&.destroy
+      cookies.delete(:session_id)
+
+      # start a new DB session and set the signed cookie
+      s = Session.create!(user: user)
+      cookies.signed[:session_id] = {
+        value: s.id,
+        httponly: true,
+        same_site: :lax
+      }
+
+      redirect_to(session.delete(:return_to) || root_path)
     else
-      redirect_to new_session_path, alert: "Try another email address or password."
+      flash.now[:alert] = "Invalid credentials"
+      render :new, status: :unauthorized
     end
   end
 
   def destroy
-    terminate_session
-    redirect_to new_session_path
+    Current.session&.destroy
+    cookies.delete(:session_id)
+    redirect_to sign_in_path, notice: "Signed out"
   end
 end

--- a/app/mailers/passwords_mailer.rb
+++ b/app/mailers/passwords_mailer.rb
@@ -1,0 +1,6 @@
+class PasswordsMailer < ApplicationMailer
+  def reset(user)
+    @user = user
+    mail subject: "Reset your password", to: user.email_address
+  end
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,0 +1,4 @@
+class Current < ActiveSupport::CurrentAttributes
+  attribute :session
+  delegate :user, to: :session, allow_nil: true
+end

--- a/app/models/current.rb
+++ b/app/models/current.rb
@@ -1,3 +1,4 @@
+# app/models/current.rb
 class Current < ActiveSupport::CurrentAttributes
   attribute :session
   delegate :user, to: :session, allow_nil: true

--- a/app/models/session.rb
+++ b/app/models/session.rb
@@ -1,0 +1,3 @@
+class Session < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,0 +1,12 @@
+class User < ApplicationRecord
+  has_secure_password
+  has_many :sessions, dependent: :destroy
+
+  normalizes :email_address, with: ->(e) { e.strip.downcase }
+
+  def display_name
+    parts = [ first_name, last_name ].compact_blank
+    return parts.join(" ") if parts.any?
+    (try(:email_address) || try(:email)).to_s
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,8 @@ class User < ApplicationRecord
     return parts.join(" ") if parts.any?
     (try(:email_address) || try(:email)).to_s
   end
+
+  def login_email
+  respond_to?(:email_address) ? email_address : (respond_to?(:email) ? email : nil)
+  end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -1,0 +1,28 @@
+<%= form_with model: [:admin, @user], local: true, class: "space-y-3" do |f| %>
+  <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-4">
+    <legend class="fieldset-legend"><%= @user.new_record? ? "New user" : "Edit user" %></legend>
+
+    <label class="label">Email</label>
+    <%= f.email_field :email_address, class: "input input-bordered w-full" %>
+
+    <div class="grid grid-cols-2 gap-3">
+      <div>
+        <label class="label">First name</label>
+        <%= f.text_field :first_name, class: "input input-bordered w-full" %>
+      </div>
+      <div>
+        <label class="label">Last name</label>
+        <%= f.text_field :last_name, class: "input input-bordered w-full" %>
+      </div>
+    </div>
+
+    <label class="label">Password <span class="opacity-60">(leave blank to keep)</span></label>
+    <%= f.password_field :password, class: "input input-bordered w-full", autocomplete: "new-password" %>
+    <%= f.password_field :password_confirmation, class: "input input-bordered w-full mt-2", autocomplete: "new-password" %>
+
+    <div class="mt-3 flex gap-2">
+      <button class="btn btn-primary">Save</button>
+      <%= link_to "Cancel", admin_users_path, class: "btn btn-ghost" %>
+    </div>
+  </fieldset>
+<% end %>

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render "form" %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,21 @@
+<div class="flex items-center justify-between mb-4">
+  <h1 class="text-2xl font-semibold">Users</h1>
+  <%= link_to "New user", new_admin_user_path, class: "btn btn-primary btn-sm" %>
+</div>
+
+<table class="table">
+  <thead><tr><th>Name</th><th>Email</th><th></th></tr></thead>
+  <tbody>
+    <% @users.each do |u| %>
+      <tr>
+        <td><%= [u.first_name,u.last_name].compact_blank.join(" ").presence || "—" %></td>
+        <td><%= u.email_address %></td>
+        <td class="text-right">
+          <%= link_to "Edit", edit_admin_user_path(u), class: "btn btn-ghost btn-xs" %>
+          <%= button_to "Delete", admin_user_path(u), method: :delete,
+                data: { turbo_confirm: "Delete this user?" }, class: "btn btn-error btn-xs" %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,1 @@
+<%= render "form" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -137,34 +137,7 @@
 
           <%= link_to "New Party", new_party_party_path, class: "btn btn-primary btn-sm hidden md:inline-flex" %>
 
-          <div class="dropdown dropdown-end">
-              <button tabindex="0" class="btn btn-ghost btn-circle btn-sm" aria-label="User menu">
-                <span class="w-8 h-8 rounded-full bg-base-300 text-base-content grid place-items-center">
-                  <svg class="w-5 h-5 block" viewBox="0 0 24 24" aria-label="User">
-                    <title>User</title>
-                    <path fill="currentColor"
-                      d="M12 14c-3.9 0-7 1.8-7 4v1h14v-1c0-2.2-3.1-4-7-4Zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"/>
-                  </svg>
-                </span>
-              </button>
-            <div tabindex="0" class="dropdown-content z-10 bg-base-100 rounded-box shadow p-3 w-64">
-              <div class="mb-2 text-sm font-semibold">Appearance</div>
-              <div class="grid grid-cols-2 gap-2 text-sm">
-                <% ["blueLight","merlotLight","blueDark","merlotDark"].each do |t| %>
-                  <label class="label cursor-pointer justify-start gap-2">
-                    <input type="radio" name="theme" value="<%= t %>" class="theme-controller">
-                    <span><%= t.gsub(/([a-z])([A-Z])/,'\1 \2').split.map(&:capitalize).join(' ') %></span>
-                  </label>
-                <% end %>
-              </div>
-              <div class="divider my-2"></div>
-              <ul class="menu">
-                <li><a href="#">Profile</a></li>
-                <li><a href="#">Sign out</a></li>
-              </ul>
-            </div>
-          </div>
-        </div>
+          <%= render "shared/user_menu" %>
 
       </div>
     </header>
@@ -178,9 +151,26 @@
     </main>
 
     <footer class="border-t">
-      <div class="max-w-7xl mx-auto p-4 text-sm opacity-70">
-        © <%= Time.current.year %> YourApp · <a href="#" class="link">Privacy</a>
+      <div class="max-w-7xl mx-auto p-4 text-sm opacity-70 flex items-center justify-between">
+        <div>
+          © <%= Time.current.year %> YourApp · <a href="#" class="link">Privacy</a>
+        </div>
+
+        <div>
+          <% if respond_to?(:authenticated?) && authenticated? %>
+            <span class="inline-flex items-center gap-2">
+              <span class="w-6 h-6 rounded-full bg-base-300 grid place-items-center">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" aria-hidden="true"><path fill="currentColor" d="M12 14c-3.9 0-7 1.8-7 4v1h14v-1c0-2.2-3.1-4-7-4Zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"/></svg>
+              </span>
+              <%= (Current.user&.display_name || Current.user&.email_address || Current.user&.email) %>
+            </span>
+          <% else %>
+            <%= link_to "Sign in", sign_in_path, class: "link" %>
+          <% end %>
+        </div>
       </div>
-    </footer>
+  </footer>
+
+
   </body>
 </html>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -138,7 +138,6 @@
           <%= link_to "New Party", new_party_party_path, class: "btn btn-primary btn-sm hidden md:inline-flex" %>
 
           <%= render "shared/user_menu" %>
-
       </div>
     </header>
 

--- a/app/views/passwords/edit.html.erb
+++ b/app/views/passwords/edit.html.erb
@@ -1,0 +1,9 @@
+<h1>Update your password</h1>
+
+<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+
+<%= form_with url: password_path(params[:token]), method: :put do |form| %>
+  <%= form.password_field :password, required: true, autocomplete: "new-password", placeholder: "Enter new password", maxlength: 72 %><br>
+  <%= form.password_field :password_confirmation, required: true, autocomplete: "new-password", placeholder: "Repeat new password", maxlength: 72 %><br>
+  <%= form.submit "Save" %>
+<% end %>

--- a/app/views/passwords/new.html.erb
+++ b/app/views/passwords/new.html.erb
@@ -1,0 +1,8 @@
+<h1>Forgot your password?</h1>
+
+<%= tag.div(flash[:alert], style: "color:red") if flash[:alert] %>
+
+<%= form_with url: passwords_path do |form| %>
+  <%= form.email_field :email_address, required: true, autofocus: true, autocomplete: "username", placeholder: "Enter your email address", value: params[:email_address] %><br>
+  <%= form.submit "Email reset instructions" %>
+<% end %>

--- a/app/views/passwords_mailer/reset.html.erb
+++ b/app/views/passwords_mailer/reset.html.erb
@@ -1,0 +1,4 @@
+<p>
+  You can reset your password within the next 15 minutes on
+  <%= link_to "this password reset page", edit_password_url(@user.password_reset_token) %>.
+</p>

--- a/app/views/passwords_mailer/reset.text.erb
+++ b/app/views/passwords_mailer/reset.text.erb
@@ -1,0 +1,2 @@
+You can reset your password within the next 15 minutes on this password reset page:
+<%= edit_password_url(@user.password_reset_token) %>

--- a/app/views/sessions/new.html.erb
+++ b/app/views/sessions/new.html.erb
@@ -1,0 +1,65 @@
+<%# app/views/sessions/new.html.erb %>
+
+<% if flash[:alert].present? %>
+  <div class="alert alert-error mb-4">
+    <span><%= flash[:alert] %></span>
+  </div>
+<% end %>
+<% if flash[:notice].present? %>
+  <div class="alert alert-success mb-4">
+    <span><%= flash[:notice] %></span>
+  </div>
+<% end %>
+
+<div class="min-h-[60vh] w-full grid place-items-center">
+  <div class="w-full max-w-sm">
+    <fieldset class="fieldset bg-base-200 border-base-300 rounded-box border p-5">
+      <legend class="fieldset-legend text-lg font-semibold">Sign in</legend>
+
+      <%= form_with url: session_path, method: :post, local: true, class: "space-y-3" do |f| %>
+        <label class="label">
+          <span class="label-text">Email</span>
+        </label>
+        <%= f.email_field :email_address,
+              required: true,
+              autofocus: true,
+              autocomplete: "username",
+              placeholder: "you@bank.tsw.email",
+              value: params[:email_address],
+              class: "input input-bordered w-full" %>
+
+        <label class="label">
+          <span class="label-text">Password</span>
+        </label>
+        <%= f.password_field :password,
+              required: true,
+              autocomplete: "current-password",
+              maxlength: 72,
+              placeholder: "••••••••",
+              class: "input input-bordered w-full" %>
+
+        <div class="flex items-center justify-between pt-2">
+          <div class="form-control">
+            <label class="cursor-pointer label gap-2">
+              <span class="label-text">Remember me</span>
+              <input type="checkbox" name="remember_me" class="checkbox checkbox-sm">
+            </label>
+          </div>
+
+          <%# Optional: forgot-password link if you add routes later %>
+          <%# <%= link_to "Forgot password?", password_path, class: "link link-hover" %> %>
+        </div>
+
+        <div class="pt-2">
+          <button class="btn btn-neutral w-full" type="submit">Login</button>
+        </div>
+      <% end %>
+    </fieldset>
+  </div>
+    <div class="card w-96 bg-base-100 card-md shadow-sm">
+    <div class="card-body">
+      <h2 class="card-title">Access Restricted</h2>
+      <p>This system is intended solely for use by authorized BankEncore personnel. If you are not an authorized user, do not attempt to log in. Unauthorized access is strictly prohibited and may be subject to disciplinary action, audit review, and legal consequences. All activity is monitored and logged in accordance with company policy and regulatory requirements.</p>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_user_menu.html.erb
+++ b/app/views/shared/_user_menu.html.erb
@@ -1,7 +1,38 @@
 <div class="dropdown dropdown-end">
-  <div tabindex="0" role="button" class="btn btn-ghost btn-sm">User</div>
-  <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box shadow p-2 w-52">
-    <li><%= link_to "Profile", "#" %></li>
-    <li><%= link_to "Sign out", destroy_user_session_path, data: { turbo_method: :delete } %></li>
-  </ul>
+  <button tabindex="0" class="btn btn-ghost btn-circle btn-sm" aria-label="User menu">
+    <span class="w-8 h-8 rounded-full bg-base-300 text-base-content grid place-items-center">
+      <svg class="w-5 h-5 block" viewBox="0 0 24 24" aria-hidden="true">
+        <path fill="currentColor" d="M12 14c-3.9 0-7 1.8-7 4v1h14v-1c0-2.2-3.1-4-7-4Zm0-2a4 4 0 1 0 0-8 4 4 0 0 0 0 8Z"/>
+      </svg>
+    </span>
+  </button>
+
+  <div tabindex="0" class="dropdown-content z-10 bg-base-100 rounded-box shadow p-3 w-64">
+    <div class="mb-2 text-sm font-semibold">Appearance</div>
+    <div class="grid grid-cols-2 gap-2 text-sm">
+      <% ["blueLight","merlotLight","blueDark","merlotDark"].each do |t| %>
+        <label class="label cursor-pointer justify-start gap-2">
+          <input type="radio" name="theme" value="<%= t %>" class="theme-controller">
+          <span><%= t.gsub(/([a-z])([A-Z])/,'\1 \2').split.map(&:capitalize).join(' ') %></span>
+        </label>
+      <% end %>
+    </div>
+
+    <div class="divider my-2"></div>
+
+    <ul class="menu">
+      <% if defined?(authenticated?) && authenticated? %>
+        <% user_label = (respond_to?(:current_user) && current_user) ? (current_user.try(:email_address) || current_user.try(:email) || "Signed in") : "Signed in" %>
+        <li class="menu-title text-xs opacity-70"><%= user_label %></li>
+        <li><%= link_to "Profile", "#" %></li>
+        <li>
+          <%= link_to "Sign out", session_path,
+              data: { turbo_method: :delete },
+              class: "text-error" %>
+        </li>
+      <% else %>
+        <li><%= link_to "Sign in", sign_in_path %></li>
+      <% end %>
+    </ul>
+  </div>
 </div>

--- a/app/views/shared/_user_menu.html.erb
+++ b/app/views/shared/_user_menu.html.erb
@@ -21,6 +21,11 @@
     <div class="divider my-2"></div>
 
     <ul class="menu">
+
+    <% if respond_to?(:authenticated?) && authenticated? && ENV["ADMIN_EMAILS"].to_s.include?(Current.user&.email_address.to_s) %>
+      <li><%= link_to "User Admin", admin_users_path %></li>
+    <% end %>
+
       <% if defined?(authenticated?) && authenticated? %>
         <% user_label = (respond_to?(:current_user) && current_user) ? (current_user.try(:email_address) || current_user.try(:email) || "Signed in") : "Signed in" %>
         <li class="menu-title text-xs opacity-70"><%= user_label %></li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,16 @@
+# config/routes.rb
 Rails.application.routes.draw do
   # sessions
   resource :session, only: %i[new create destroy]
-
-  # pretty aliases
   get    "sign_in",  to: "sessions#new",     as: :sign_in
   delete "sign_out", to: "sessions#destroy", as: :sign_out
 
+  # hidden admin scope
+  namespace :admin, path: "/_internal/admin" do
+    resources :users, only: %i[index new create edit update destroy]
+  end
+
+  # health + root
   get "up" => "rails/health#show", as: :rails_health_check
   root "home#index"
 
@@ -25,29 +30,22 @@ Rails.application.routes.draw do
       resources :addresses, only: %i[index new create edit update destroy] do
         member { patch :primary }
       end
+
+      # nested create/index for screenings
+      resources :screenings, only: %i[new create index]
     end
+
+    # global screenings by id
+    resources :screenings, only: %i[show edit update]
 
     resources :groups do
       resources :group_memberships, path: :memberships, only: %i[index create destroy]
     end
 
     resources :links, only: %i[index create destroy]
-
-    resources :parties, param: :public_id do
-    resources :screenings, only: [ :new, :create, :index ]
-  end
-    resources :screenings, only: [ :show, :edit, :update ]
   end
 
   namespace :ref do
     resources :regions, only: :index
-  end
-
-  namespace :ref do
-    resources :regions, only: :index
-  end
-
-  def index
-    redirect_to party_party_path(@party.public_id, anchor: "addresses")
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,11 @@
 Rails.application.routes.draw do
+  # sessions
+  resource :session, only: %i[new create destroy]
+
+  # pretty aliases
+  get    "sign_in",  to: "sessions#new",     as: :sign_in
+  delete "sign_out", to: "sessions#destroy", as: :sign_out
+
   get "up" => "rails/health#show", as: :rails_health_check
   root "home#index"
 

--- a/db/migrate/20250930145727_create_users.rb
+++ b/db/migrate/20250930145727_create_users.rb
@@ -1,0 +1,11 @@
+class CreateUsers < ActiveRecord::Migration[8.0]
+  def change
+    create_table :users do |t|
+      t.string :email_address, null: false
+      t.string :password_digest, null: false
+
+      t.timestamps
+    end
+    add_index :users, :email_address, unique: true
+  end
+end

--- a/db/migrate/20250930145729_create_sessions.rb
+++ b/db/migrate/20250930145729_create_sessions.rb
@@ -1,0 +1,11 @@
+class CreateSessions < ActiveRecord::Migration[8.0]
+  def change
+    create_table :sessions do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :ip_address
+      t.string :user_agent
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250930160022_add_names_to_users.rb
+++ b/db/migrate/20250930160022_add_names_to_users.rb
@@ -1,0 +1,6 @@
+class AddNamesToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_30_050156) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_30_160022) do
   create_table "customer_number_counters", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "current_value", null: false
     t.integer "min_value", default: 1001, null: false
@@ -269,6 +269,25 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_30_050156) do
     t.index ["country_code"], name: "fk_rails_27cb4ed1c4"
   end
 
+  create_table "sessions", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "ip_address"
+    t.string "user_agent"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_sessions_on_user_id"
+  end
+
+  create_table "users", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
+    t.string "email_address", null: false
+    t.string "password_digest", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
+    t.index ["email_address"], name: "index_users_on_email_address", unique: true
+  end
+
   add_foreign_key "party_addresses", "parties", on_delete: :cascade
   add_foreign_key "party_addresses", "ref_address_types", column: "address_type_code", primary_key: "code"
   add_foreign_key "party_addresses", "ref_regions", column: ["country_code", "region_code"], primary_key: ["country_code", "code"], name: "fk_pa_ref_regions_ccode_rcode"
@@ -289,4 +308,5 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_30_050156) do
   add_foreign_key "party_phones", "ref_phone_types", column: "phone_type_code", primary_key: "code"
   add_foreign_key "party_screenings", "parties", on_delete: :cascade
   add_foreign_key "ref_regions", "ref_countries", column: "country_code", primary_key: "code"
+  add_foreign_key "sessions", "users"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -101,6 +101,12 @@ SEED_CONFIG = {
   ]
 }
 
+User.find_or_create_by!(email_address: "admin@example.com") do |u|
+  u.password = "ChangeMe123!"
+  u.first_name = "Admin"
+  u.last_name  = "User"
+end
+
 SEED_CONFIG.each do |klass_name, rows|
   seed_records_by!(klass_name, rows, by: :code, timestamp: timestamp)
 end

--- a/docs/adrs/0023-authn-rails8-native-sessions.md
+++ b/docs/adrs/0023-authn-rails8-native-sessions.md
@@ -1,0 +1,27 @@
+# Adr: 0023
+title: Use Rails 8 native Authentication with DB-backed Session model
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+We need simple, reliable authentication now. We already use the Rails 8 Auth concern (`Authentication`) which expects a DB-backed `Session` and a signed cookie `session_id`. Devise would add complexity we do not need yet.
+
+## Decision
+Adopt the Rails 8 generator pattern:
+- Keep `Authentication` concern and `Session` model.
+- Set and revoke sessions manually:
+  - Create: `s = Session.create!(user:) ; cookies.signed[:session_id] = s.id`
+  - Destroy: `Current.session&.destroy ; cookies.delete(:session_id)`
+- Use helpers from the concern (`authenticated?`, `current_user`) and do **not** introduce `session[:user_id]`.
+
+## Consequences
+- Minimal code, easy to read.
+- Migration to Devise/Rodauth remains possible.
+- Password reset and 2FA will be separate ADRs.
+
+## Implementation Notes
+- `SessionsController#create` authenticates via `user.authenticate(password)` and sets the cookie + row.
+- `SessionsController#destroy` revokes both.
+- Routes: `resource :session, only: %i[new create destroy]`.

--- a/docs/adrs/0024-authn-admin-gate-and-routing.md
+++ b/docs/adrs/0024-authn-admin-gate-and-routing.md
@@ -1,0 +1,29 @@
+adr: 0024
+title: Gate admin UI via allowlist and namespaced routes
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+We need a hidden user-admin screen. Only specific emails may access it.
+
+## Decision
+- Namespace admin routes under `/_internal/admin`.
+- Allowlist emails via `ENV["ADMIN_EMAILS"]`.
+- Gate with a controller concern `AdminGate` that:
+  - Redirects unauthenticated users to sign-in and stores `session[:return_to]`.
+  - Compares `current_user.email_address.downcase` against the normalized allowlist.
+  - Returns 403 for authenticated but unauthorized users.
+
+## Consequences
+- No coupling to future RBAC; low risk.
+- Ops must set `ADMIN_EMAILS` in each environment.
+
+## Implementation Notes
+- Routes:
+  ```ruby
+  namespace :admin, path: "/_internal/admin" do
+    resources :users, only: %i[index new create edit update destroy]
+  end
+Link helpers: admin_users_path, new_admin_user_path, etc.

--- a/docs/adrs/0025-authn-current-and-view-helpers.md
+++ b/docs/adrs/0025-authn-current-and-view-helpers.md
@@ -1,0 +1,35 @@
+adr: 0025
+title: Use Current.session → Current.user and Authentication helpers in views
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+We previously mixed `Current.user=` and `session[:user_id]` with the Rails 8 pattern, causing loops and stale sessions.
+
+## Decision
+- Keep `app/models/current.rb`:
+  ```ruby
+  class Current < ActiveSupport::CurrentAttributes
+    attribute :session
+    delegate :user, to: :session, allow_nil: true
+  end
+Do not assign Current.user= anywhere.
+
+In controllers and views, use:
+
+authenticated? and current_user (provided by Authentication).
+
+current_user.display_name for menus/footers.
+
+Consequences
+Single source of truth for auth context.
+
+Fewer failure modes.
+
+Implementation Notes
+Footer/menu conditions: <% if authenticated? %> … <% end %>.
+
+---
+

--- a/docs/adrs/0026-authn-login-flow-and-return-to.md
+++ b/docs/adrs/0026-authn-login-flow-and-return-to.md
@@ -1,0 +1,20 @@
+adr: 0026
+title: Preserve destination via session return_to during login
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+Users hitting gated pages should return there after login.
+
+## Decision
+- In `AdminGate` (and any future gates), store `session[:return_to] = request.fullpath` before redirecting.
+- In `SessionsController#create`, after successful auth:
+  ```ruby
+  redirect_to(session.delete(:return_to) || root_path)
+Consequences
+Predictable UX across gated routes.
+
+Risks
+Ensure return_to is cleared with delete to prevent open redirect loops.

--- a/docs/adrs/0027-authn-user-admin-ui-scope-and-guards.md
+++ b/docs/adrs/0027-authn-user-admin-ui-scope-and-guards.md
@@ -1,0 +1,23 @@
+adr: 0027
+title: Minimal internal User Admin UI under admin namespace
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+We need to create and update users internally.
+
+## Decision
+- Build a small CRUD (`Admin::UsersController`) for `User` with fields:
+  `email_address`, `first_name`, `last_name`, `password`, `password_confirmation`.
+- Use DaisyUI patterns already in the app.
+- Namespaced form: `form_with model: [:admin, @user]`.
+
+## Consequences
+- Admin UX is isolated from public surface.
+- Future RBAC can reuse the namespace.
+
+## Implementation Notes
+- Redirects and links use `admin_*` helpers only.
+- Cancel links go to `admin_users_path`.

--- a/docs/adrs/0028-authn-auditing-integration.md
+++ b/docs/adrs/0028-authn-auditing-integration.md
@@ -1,0 +1,27 @@
+adr: 0028
+title: Tie auditing to current authenticated user
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+We require “who did what” across screenings and party CRUD.
+
+## Decision
+- Use an `AuditLog` table with `user_id`, `subject_type`, `subject_id`, `action`, `changeset(json)`, `ip`, `ua`, `at`.
+- Add an `Auditable` concern:
+  - `after_create/update/destroy` write a row using `current_user` (via `Authentication`) or `Current.user`.
+- Do not block on full RBAC. All users are effectively admins for now.
+
+## Consequences
+- Audits start capturing actor identity immediately.
+- Future RBAC strengthens policies without changing audit plumbing.
+
+## Implementation Notes
+- Populate IP/UA in a lightweight before_action:
+  ```ruby
+  before_action do
+    Current.ip = request.remote_ip rescue nil
+    Current.ua = request.user_agent rescue nil
+  end

--- a/docs/adrs/0029-authn-security-scope-and-deferrals.md
+++ b/docs/adrs/0029-authn-security-scope-and-deferrals.md
@@ -1,0 +1,24 @@
+adr: 0024
+title: Security baseline now; defer password reset and 2FA
+status: Accepted
+date: 2025-09-30
+deciders: Core team
+---
+
+## Context
+We need to ship internal auth quickly. Reset links and MFA add scope.
+
+## Decision
+- Ship without password reset and 2FA initially.
+- Add later behind separate ADRs:
+  - **Password reset**: token table, expiring links, email delivery, throttle.
+  - **2FA**: TOTP or WebAuthn; enforce for admin-equivalent users.
+
+## Consequences
+- Reduced initial complexity.
+- Internal-only deployments must use strong manual password hygiene.
+
+## Interim Controls
+- Enforce bcrypt (`has_secure_password` via generator).
+- Rate-limit auth endpoints (Rack::Attack) before external exposure.
+- Use `ADMIN_EMAILS` allowlist for admin UI.

--- a/script/ci.sh
+++ b/script/ci.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+bundle exec rubocop $1

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :user do
+    email_address { "user@example.com" }
+    password { "password" }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/test/mailers/previews/passwords_mailer_preview.rb
+++ b/test/mailers/previews/passwords_mailer_preview.rb
@@ -1,0 +1,7 @@
+# Preview all emails at http://localhost:3000/rails/mailers/passwords_mailer
+class PasswordsMailerPreview < ActionMailer::Preview
+  # Preview this email at http://localhost:3000/rails/mailers/passwords_mailer/reset
+  def reset
+    PasswordsMailer.reset(User.take)
+  end
+end


### PR DESCRIPTION
## Auth: Rails 8 native sessions + admin gate + user admin UI + audit hooks

**PR description**

* Implements Rails 8 Authentication with DB-backed `Session` model.
* Adds hidden admin namespace `/_internal/admin` with basic User CRUD.
* Introduces allowlist gate for admin UI via `ADMIN_EMAILS`.
* Wires logout to destroy DB session and clear cookie.
* Preps auditing to capture `current_user`.

### Changes

* `app/controllers/sessions_controller.rb`: create/destroy DB sessions; set `cookies.signed[:session_id]`.
* `config/routes.rb`: `resource :session` + `sign_in`/`sign_out`; `namespace :admin, path: "/_internal/admin"` for users.
* `app/controllers/concerns/admin_gate.rb`: allowlist gate; stores `session[:return_to]`.
* `app/models/current.rb`: keep `session` delegation.
* `app/views/sessions/new.html.erb`: DaisyUI sign-in form.
* `app/views/shared/_user_menu.html.erb`: proper logout; shows `current_user`.
* `app/views/layouts/application.html.erb`: footer shows signed-in user.
* `app/controllers/admin/users_controller.rb` + views: minimal CRUD, namespaced paths, DaisyUI forms.
* Fixes references to `email_address` vs `email`.

### Env

* Add to `.env` (or deployment env):

  ```
  ADMIN_EMAILS=admin@example.com,syckot@bank.tsw.email
  ```

### Migrations

* None for auth beyond prior `users`/`sessions` tables already present.

### How to test

1. Start server.
2. Visit `/_internal/admin/users` → redirected to `/sign_in`.
3. Sign in as allowlisted user → lands on admin users index.
4. Create/edit a user. Save returns to index.
5. Use user menu “Sign out” → cookie cleared; accessing admin redirects to sign-in.
6. Sign in as non-allowlisted user → `/_internal/admin/users` returns 403.
7. Footer shows current user’s display name.

### Security

* Sessions are DB-backed; logout revokes server-side.
* Admin UI gated by allowlist. No public links.
* No password reset or MFA yet (tracked for later).

### Follow-ups

* Add Pundit and module-level permissions.
* Add `AuditLog` + `Auditable` concern on critical models.
* Password reset and 2FA (separate PRs).
* Admin UI: pagination and search.

### Screenshots (optional)

* Sign-in page
* Admin users index
* Admin user edit form

**Merge note**
Safe to deploy. Set `ADMIN_EMAILS` before exposing the admin URL.
