### PR TITLE
Fix/parties/refactor party id masking

### DIFF
--- a/app/models/party/identifier.rb
+++ b/app/models/party/identifier.rb
@@ -45,8 +45,8 @@ module Party
       rule = identifier_type&.mask_rule.to_s
 
       case rule
-      when "ssn"     # 9 digits → ***-**-1234
-        (value_len == 9 && value_last4.present?) ? "***-**-#{value_last4}" : masked
+      when "ssn"     # 9 digits → •••-••-1234
+        (value_len == 9 && value_last4.present?) ? "•••-••-#{value_last4}" : masked
       when "ein"     # policy: hide prefix completely
         masked
       when "last4"   # generic last4

--- a/app/models/party/identifier.rb
+++ b/app/models/party/identifier.rb
@@ -37,7 +37,7 @@ module Party
     def masked(keep: 4, mask: "•")
       len = value_len.to_i
       return "" if len <= 0
-      k = [keep, len].min
+      k = [ keep, len ].min
       mask * (len - k) + value_last4.to_s.last(k)
     end
 
@@ -46,13 +46,13 @@ module Party
 
       case rule
       when "ssn"     # 9 digits → ***-**-1234
-        return (value_len == 9 && value_last4.present?) ? "***-**-#{value_last4}" : masked
+        (value_len == 9 && value_last4.present?) ? "***-**-#{value_last4}" : masked
       when "ein"     # policy: hide prefix completely
-        return masked
+        masked
       when "last4"   # generic last4
-        return masked
+        masked
       when /\Apattern:(\d+)-(\d+)-(\d+)\z/ # e.g. "pattern:3-2-4"
-        g1,g2,g3 = [$1,$2,$3].map!(&:to_i)
+        g1, g2, g3 = [ $1, $2, $3 ].map!(&:to_i)
         return masked if value_len != (g1+g2+g3) || value_last4.blank?
         # Only reveal last group’s last digits
         "•" * g1 + "-" + "•" * g2 + "-" + value_last4.rjust(g3, "•")

--- a/app/models/ref/identifier_type.rb
+++ b/app/models/ref/identifier_type.rb
@@ -2,8 +2,16 @@
 module Ref
   class IdentifierType < ApplicationRecord
     self.table_name = "ref_identifier_types"
-    has_many :identifiers, class_name: "::Party::Identifier",
-      foreign_key: :identifier_type_id, inverse_of: :identifier_type
+
+    has_many :identifiers,
+      class_name: "::Party::Identifier",
+      foreign_key: :identifier_type_id,
+      inverse_of: :identifier_type
+
     validates :code, :name, presence: true
+    validates :code, uniqueness: true
+    validates :mask_rule,
+      format: { with: /\A(?:last4|ssn|ein|none|pattern:\d+-\d+-\d+)\z/ },
+      allow_blank: true
   end
 end

--- a/bankencorre.sql
+++ b/bankencorre.sql
@@ -69,7 +69,7 @@ CREATE TABLE `customer_number_counters` (
 LOCK TABLES `customer_number_counters` WRITE;
 /*!40000 ALTER TABLE `customer_number_counters` DISABLE KEYS */;
 INSERT INTO `customer_number_counters` VALUES
-(1,1001,1001,9999999,'2025-09-30 05:04:29.865288','2025-09-30 05:04:29.877579');
+(1,1013,1001,9999999,'2025-09-30 05:04:29.865288','2025-10-01 02:18:29.061532');
 /*!40000 ALTER TABLE `customer_number_counters` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -93,7 +93,7 @@ CREATE TABLE `parties` (
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_parties_on_public_id` (`public_id`),
   UNIQUE KEY `index_parties_on_customer_number` (`customer_number`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -103,7 +103,19 @@ CREATE TABLE `parties` (
 LOCK TABLES `parties` WRITE;
 /*!40000 ALTER TABLE `parties` DISABLE KEYS */;
 INSERT INTO `parties` VALUES
-(1,'2ce2c990-c881-408f-8295-6c1fe97e6800','0001001258','person','2025-09-30 05:04:29.980987','2025-09-30 05:04:29.980987',NULL,NULL,NULL);
+(1,'2ce2c990-c881-408f-8295-6c1fe97e6800','0001001258','person','2025-09-30 05:04:29.980987','2025-09-30 05:04:29.980987',NULL,NULL,NULL),
+(2,'438bca3f-14b9-4134-b313-7ceebb21bc4d','0001002257','person','2025-10-01 01:55:59.168586','2025-10-01 01:55:59.168586',NULL,NULL,NULL),
+(3,'00f3926e-7db1-4101-8ada-e70cce2c08d5','0001003256','person','2025-10-01 01:58:00.106766','2025-10-01 01:58:00.106766',NULL,NULL,NULL),
+(4,'d48dbcf3-63d5-48ed-bb80-4b64bad49241','0001004255','person','2025-10-01 01:59:31.118296','2025-10-01 01:59:31.118296',NULL,NULL,NULL),
+(5,'c74c07af-703a-4412-a5a5-bdfd832ce304','0001005254','person','2025-10-01 02:00:48.768010','2025-10-01 02:00:48.768010',NULL,NULL,NULL),
+(6,'06e29c8e-487f-4bf1-af04-1cf3460a3c6b','0001006253','person','2025-10-01 02:02:09.638871','2025-10-01 02:02:09.638871',NULL,NULL,NULL),
+(7,'88acfb12-b1f5-4872-b9e8-8062842be876','0001007252','person','2025-10-01 02:03:38.018608','2025-10-01 02:03:38.018608',NULL,NULL,NULL),
+(8,'984f54a0-d009-4edd-9a65-a019a349b0e3','0001008251','person','2025-10-01 02:05:01.170554','2025-10-01 02:05:01.170554',NULL,NULL,NULL),
+(9,'d31a3a9e-033e-4ce1-bd8f-daf611de4de5','0001009250','person','2025-10-01 02:06:28.764184','2025-10-01 02:06:28.764184',NULL,NULL,NULL),
+(10,'defc4901-3881-4c42-94bf-1a1852dc74cb','0001010257','person','2025-10-01 02:08:22.059129','2025-10-01 02:08:22.059129','2025-09-30 22:22:00.000000',NULL,NULL),
+(11,'504bb639-7c2b-496c-bdc3-6b141f5a917e','0001011256','person','2025-10-01 02:10:37.149356','2025-10-01 02:10:37.149356',NULL,NULL,NULL),
+(12,'c16d0aca-d2c7-4e88-afa4-fd3d6cd70e46','0001012255','organization','2025-10-01 02:16:26.655781','2025-10-01 02:16:26.655781',NULL,NULL,NULL),
+(13,'5d414972-072b-487e-a6cd-8da5ced26b92','0001013254','person','2025-10-01 02:18:29.114630','2025-10-01 02:18:29.114630',NULL,NULL,NULL);
 /*!40000 ALTER TABLE `parties` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -137,7 +149,7 @@ CREATE TABLE `party_addresses` (
   CONSTRAINT `fk_pa_ref_regions_ccode_rcode` FOREIGN KEY (`country_code`, `region_code`) REFERENCES `ref_regions` (`country_code`, `code`),
   CONSTRAINT `fk_rails_d3cf0b1de6` FOREIGN KEY (`address_type_code`) REFERENCES `ref_address_types` (`code`),
   CONSTRAINT `fk_rails_d458941a1f` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -147,7 +159,20 @@ CREATE TABLE `party_addresses` (
 LOCK TABLES `party_addresses` WRITE;
 /*!40000 ALTER TABLE `party_addresses` DISABLE KEYS */;
 INSERT INTO `party_addresses` VALUES
-(1,1,'residential','118 Bubby Dr','','','Austin','TX','78759','US',1,'2025-09-30 05:04:30.002732','2025-09-30 05:04:30.002732');
+(1,1,'residential','118 Bubby Dr','','','Austin','TX','78759','US',1,'2025-09-30 05:04:30.002732','2025-09-30 05:04:30.002732'),
+(2,2,'residential','4789 Ottis St','','','Edmund','OK','73034','US',1,'2025-10-01 01:55:59.192743','2025-10-01 01:55:59.192743'),
+(3,3,'residential','442 Glenview Dr','','','Corpus Christi','TX','78476','US',1,'2025-10-01 01:58:00.125734','2025-10-01 01:58:00.125734'),
+(4,4,'residential','496 Losh Ln','','','Pittsburgh','PA','15212','US',1,'2025-10-01 01:59:31.131902','2025-10-01 01:59:31.131902'),
+(5,5,'residential','245 Fancher Dr','','','Dallas','TX','75218','US',1,'2025-10-01 02:00:48.791564','2025-10-01 02:00:48.791564'),
+(6,6,'residential','4117 Randolph St','','','South Boston','MA','02127','US',1,'2025-10-01 02:02:09.648607','2025-10-01 02:02:09.648607'),
+(7,7,'residential','554 Plainfield Ave','','','Utica','NY','13502','US',1,'2025-10-01 02:03:38.037666','2025-10-01 02:03:38.037666'),
+(8,8,'residential','2694 Stanley Ave','','','Westbury','NY','11590','US',1,'2025-10-01 02:05:01.178536','2025-10-01 02:05:01.178536'),
+(9,9,'residential','1340 Nutter St','Apt 115','','Cameron','MO','64429','US',1,'2025-10-01 02:06:28.774755','2025-10-01 02:06:28.774755'),
+(10,10,'residential','3721 Glenwood Ave','','','Cleveland','OH','44114','US',1,'2025-10-01 02:08:22.070649','2025-10-01 02:08:22.070649'),
+(11,11,'residential','2485 Hinkle Deegan Lake Rd','','','Binghamton','NY','13901','US',1,'2025-10-01 02:10:37.162819','2025-10-01 02:10:37.162819'),
+(12,10,'former','347 Flanigan Oaks Dr','','','Capitol Heights','MD','20027','US',0,'2025-10-01 02:13:23.684221','2025-10-01 02:13:23.684221'),
+(13,12,'business','2806 Masonic Dr','Ste 215','Amalia R Lazo','Victor','MT','59875','US',1,'2025-10-01 02:16:26.668794','2025-10-01 02:16:26.668794'),
+(14,13,'residential','2806 Masonic Dr','','','Victor','MT','59875','US',1,'2025-10-01 02:18:29.124938','2025-10-01 02:18:29.124938');
 /*!40000 ALTER TABLE `party_addresses` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -176,7 +201,7 @@ CREATE TABLE `party_emails` (
   KEY `index_party_emails_on_party_id` (`party_id`),
   CONSTRAINT `fk_rails_18957eb6d4` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_rails_77478fab14` FOREIGN KEY (`email_type_code`) REFERENCES `ref_email_types` (`code`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -186,7 +211,19 @@ CREATE TABLE `party_emails` (
 LOCK TABLES `party_emails` WRITE;
 /*!40000 ALTER TABLE `party_emails` DISABLE KEYS */;
 INSERT INTO `party_emails` VALUES
-(1,1,'personal','ª%+“–>²—f¼´\rº\\1®È™tÛ3ÍÚ-{–e3','s**********s@rhyta.com','rhyta.com',1,'2025-09-30 05:04:30.009664','2025-09-30 05:04:30.009664','{\"p\":\"Ow246Ir3+8wWYGJy+BubBKSjjgLj6A==\",\"h\":{\"iv\":\"ecRoahE57U5yz1Nt\",\"at\":\"luoFtSx1c3Z+byb6WY41OQ==\"}}');
+(1,1,'personal','ª%+“–>²—f¼´\rº\\1®È™tÛ3ÍÚ-{–e3','s**********s@rhyta.com','rhyta.com',1,'2025-09-30 05:04:30.009664','2025-09-30 05:04:30.009664','{\"p\":\"Ow246Ir3+8wWYGJy+BubBKSjjgLj6A==\",\"h\":{\"iv\":\"ecRoahE57U5yz1Nt\",\"at\":\"luoFtSx1c3Z+byb6WY41OQ==\"}}'),
+(2,2,'personal','ìd˜êq®Ğ,¾ÿ€èbÆ~2dF‹²øÈÒ3î¨dû …','r*************r@armyspy.com','armyspy.com',1,'2025-10-01 01:55:59.203496','2025-10-01 01:55:59.203496','{\"p\":\"znYANH/pcyKSlLun6jMWmiugeix+juXQ+BD1\",\"h\":{\"iv\":\"6w9ZpvEM/bPFwSwb\",\"at\":\"y1V/Zabpy8+TsxmLBxF1XQ==\"}}'),
+(3,3,'personal','¢¬0\Z\råç/Ù×®HtL¼\râª_×•RŸ‚<uhÔ½6','j**********z@jourrapide.com','jourrapide.com',1,'2025-10-01 01:58:00.142702','2025-10-01 01:58:00.142702','{\"p\":\"SjldQn07fwpnsaEDIg1DAsYu3RNWF0eGGHTR\",\"h\":{\"iv\":\"Rckzf4qDPbhDpCT2\",\"at\":\"6kx0y/KAXYUb1x3SYZRtuA==\"}}'),
+(4,4,'personal','CÕKó\"ıôeš;n1\0ó™«´$cì2L¹uÑÁ‰!|‘','k**********s@rhyta.com','rhyta.com',1,'2025-10-01 01:59:31.139229','2025-10-01 01:59:31.139229','{\"p\":\"evGu7ZNFwIa7ZfOXGhRPWDn9bX1WAA==\",\"h\":{\"iv\":\"2+P20X3xzA1ZgWMZ\",\"at\":\"9BsawQGuN7bZ94+bT6ZZIw==\"}}'),
+(5,5,'personal','èÕK™É·Ñ0Ÿ1Òx¼j÷&,H·•—6¼fy.','j**********k@dayrep.com','dayrep.com',1,'2025-10-01 02:00:48.798113','2025-10-01 02:00:48.798113','{\"p\":\"c6005TgkoHjYWTTXUQcVELa2YM9EGLU=\",\"h\":{\"iv\":\"2+VV+POavgrtxSzo\",\"at\":\"0SQ0NV/7WwsDwpEvKV8wdA==\"}}'),
+(6,6,'personal','¶{ç«ü\"áëœL²8áëúÌV˜÷éSxü¼Ò‘','w************s@dayrep.com','dayrep.com',1,'2025-10-01 02:02:09.653228','2025-10-01 02:02:09.653228','{\"p\":\"T2X1n2OtYJygNDB2QRQ+5K+zPba87SsmiA==\",\"h\":{\"iv\":\"yfIzHnf6sRTrgoJV\",\"at\":\"Il2DHtnbAWpHzsXiWaY3bw==\"}}'),
+(7,7,'personal','Ö„æøÊ‰_\"’ß+)Ú‚X†ÊŞ.¾€|âVfeî”\Zâ','l********l@jourrapide.com','jourrapide.com',1,'2025-10-01 02:03:38.046831','2025-10-01 02:03:38.046831','{\"p\":\"lLd5jsc9AsQIXJhi4RFhvd4tS4GRkI9Z2Q==\",\"h\":{\"iv\":\"OSMEXHRolY+yFekq\",\"at\":\"SOvAc5g+4HG02QrLLnPRSA==\"}}'),
+(8,8,'personal','cÈ*ŠWyŒÈ=»nBsÉ8Ô•R3j9îHÒùS]','p**********s@teleworm.us','teleworm.us',1,'2025-10-01 02:05:01.182756','2025-10-01 02:05:01.182756','{\"p\":\"NhhTwCq/kQH3W81g8dj0gcsspYsIYFvu\",\"h\":{\"iv\":\"61OHs1pLD+9Cav5h\",\"at\":\"ovOmJHx2JPtnOv1S4nCJJw==\"}}'),
+(9,9,'personal','İ—õæÂd‰[„LLÅ.V&q©Í‘ĞtÎN','e**********t@rhyta.com','rhyta.com',1,'2025-10-01 02:06:28.782040','2025-10-01 02:06:35.624526','{\"p\":\"H67xvMfasyQ9r1/ynmepjiNG0CStSA==\",\"h\":{\"iv\":\"GNSKgD+FDQ4fBauO\",\"at\":\"xbYayWkZzeFqpwhIZDBs/w==\"}}'),
+(10,10,'personal','ÎSàş+’ìçÃcî>¤ÂtıãYbå#£¶','j**********y@jourrapide.com','jourrapide.com',1,'2025-10-01 02:08:22.076491','2025-10-01 02:08:22.076491','{\"p\":\"NqBgxLgC8dXTiQtoudvTdi10aY6GteG4B9ix\",\"h\":{\"iv\":\"Wj/Zd2mrN+/Lppnu\",\"at\":\"dd3YLaK56olmnEpGHxLPyw==\"}}'),
+(11,11,'personal','F‡ì‘Èu)b™rÚjz+áÏ/ v‰Šë…µ·ÖY<','d**********n@rhyta.com','rhyta.com',1,'2025-10-01 02:10:37.168093','2025-10-01 02:10:37.168093','{\"p\":\"OGyFLi4BMLXfROQkZr/MjGZTgCUOUA==\",\"h\":{\"iv\":\"UTmtYUtkz4vcXezz\",\"at\":\"RAgkdGqtnSPa5XyasQWDzA==\"}}'),
+(12,12,'other','rêbßME»Q«})_$DÎ<‰·Nn™jÌë;¸fï','a*********o@teleworm.us','teleworm.us',1,'2025-10-01 02:16:26.672360','2025-10-01 02:16:26.672360','{\"p\":\"akbonm7nRmiohixpRnemRrw6cBbescE=\",\"h\":{\"iv\":\"4wEkbme2slqT2k+t\",\"at\":\"3y08h3yfJ98vBuqyqqHAmg==\"}}'),
+(13,13,'work','rêbßME»Q«})_$DÎ<‰·Nn™jÌë;¸fï','a*********o@teleworm.us','teleworm.us',1,'2025-10-01 02:18:29.129101','2025-10-01 02:18:29.129101','{\"p\":\"akbonm7nRmiohixpRnemRrw6cBbescE=\",\"h\":{\"iv\":\"4wEkbme2slqT2k+t\",\"at\":\"3y08h3yfJ98vBuqyqqHAmg==\"}}');
 /*!40000 ALTER TABLE `party_emails` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -285,7 +322,7 @@ CREATE TABLE `party_identifiers` (
   CONSTRAINT `fk_rails_7fab1c3b2b` FOREIGN KEY (`identifier_type_id`) REFERENCES `ref_identifier_types` (`id`),
   CONSTRAINT `fk_rails_936acac377` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`),
   CONSTRAINT `metadata` CHECK (json_valid(`metadata`))
-) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=16 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -296,7 +333,20 @@ LOCK TABLES `party_identifiers` WRITE;
 /*!40000 ALTER TABLE `party_identifiers` DISABLE KEYS */;
 INSERT INTO `party_identifiers` VALUES
 (1,1,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"4daLDsi9LwSP\",\"h\":{\"iv\":\"pRpYUQN27W5F2hn/\",\"at\":\"cegls0SqTL5sueNbtuhWlQ==\"}}','hxÕmšNfex}ÀªJ—á	¿4ÌÎ¸ª–¾åû%ÿ†','****',NULL,NULL,NULL,'2025-09-30 05:04:30.111919','2025-09-30 05:04:30.111919',1),
-(2,1,'dl','',NULL,'2022-01-15','2027-02-01',NULL,0,'{\"p\":\"o2DWvHHrlFmrbg==\",\"h\":{\"iv\":\"bHx8VxCzWt+6Sj+b\",\"at\":\"nI/GX+hmhKRIn4pEvsjUCQ==\"}}','{¬ØÎ‚sj*“ìkãM ûD$5ËzkU6Ë','****',NULL,NULL,NULL,'2025-09-30 16:25:15.686694','2025-09-30 16:25:15.686694',5);
+(2,1,'dl','',NULL,'2022-01-15','2027-02-01',NULL,0,'{\"p\":\"o2DWvHHrlFmrbg==\",\"h\":{\"iv\":\"bHx8VxCzWt+6Sj+b\",\"at\":\"nI/GX+hmhKRIn4pEvsjUCQ==\"}}','{¬ØÎ‚sj*“ìkãM ûD$5ËzkU6Ë','****',NULL,NULL,NULL,'2025-09-30 16:25:15.686694','2025-09-30 16:25:15.686694',5),
+(3,2,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"b8x31n5SYJYk\",\"h\":{\"iv\":\"/19FR9SYaej20N5v\",\"at\":\"k4CmL0bPQ6NBmX/iYQp5+g==\"}}','x8C9½ÈúZ¿àiybY—¿Ëbëìãáõ¡Ò+t','****',NULL,NULL,NULL,'2025-10-01 01:55:59.225162','2025-10-01 01:55:59.225162',1),
+(4,3,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"DQF/LEmMAfrz\",\"h\":{\"iv\":\"SczqJKoghao8S7LM\",\"at\":\"2+wLXhiFu33WyI4KuRwv2g==\"}}','ù#P\'¨€—\"–Râ€»In%5gÀá­ÖîĞpgè/~×','****',NULL,NULL,NULL,'2025-10-01 01:58:00.155591','2025-10-01 01:58:00.155591',1),
+(5,4,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"QtYLzQfZzhFZ\",\"h\":{\"iv\":\"S5HpSVL4KLacDL5/\",\"at\":\"BL9QcT+gro+Ab60Ygao+2A==\"}}','ãõÄB’GFzÇ¯B0up¿=\ré»!­Åy°—¿','****',NULL,NULL,NULL,'2025-10-01 01:59:31.148312','2025-10-01 01:59:31.148312',1),
+(6,5,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"+anoGGBENX4X\",\"h\":{\"iv\":\"g5OwJPGlQaFZbY6Y\",\"at\":\"yFZ+MP6H2ek9wTZDY/QLSA==\"}}','ÎíCs¢|#pÃHzÚk–Å|ÌY—8Â9í³·Aa&','****',NULL,NULL,NULL,'2025-10-01 02:00:48.809345','2025-10-01 02:00:48.809345',1),
+(7,6,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"XqQOjNfySAIq\",\"h\":{\"iv\":\"O5F7JymjAh61LfgP\",\"at\":\"rNhoiy07hZ1G7Ywx61J5wQ==\"}}','(¥XÚ5$~Ñq\rswöœvlYı·éR²(øÎ65Ê','****',NULL,NULL,NULL,'2025-10-01 02:02:09.659783','2025-10-01 02:02:09.659783',1),
+(8,7,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"RHlpXgbI9lpV\",\"h\":{\"iv\":\"x/8B7fIP9wrP+8Sv\",\"at\":\"meB9EO44G1PaLgm4YLOq6A==\"}}','U-%˜÷p¥ºh»€=aCY\n]†[c^è ’ŸÓe','****',NULL,NULL,NULL,'2025-10-01 02:03:38.063313','2025-10-01 02:03:38.063313',1),
+(9,8,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"uxnIwfY2Nw8s\",\"h\":{\"iv\":\"3GP+SPKX8IaEj4/F\",\"at\":\"WOo+vSrd/nwN4cUxP/QqUg==\"}}','eû·ú\n’;K±ı‡é¼?~LJ1†E°¾‡Ùü`Ë\\','****',NULL,NULL,NULL,'2025-10-01 02:05:01.190379','2025-10-01 02:05:01.190379',1),
+(10,9,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"n26JhqX6NFCO\",\"h\":{\"iv\":\"zqINSHN0jR0TexVI\",\"at\":\"iZvvI+fM0XE6CHXDTI0Pvw==\"}}','{½‹-bqf¿¡;Ó?SğóÔd=ûlö3,s÷HY¨9','****',NULL,NULL,NULL,'2025-10-01 02:06:28.791240','2025-10-01 02:06:28.791240',1),
+(11,10,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"/OhQZ0U6muo2\",\"h\":{\"iv\":\"DH/7CgjMZ+lyIYMP\",\"at\":\"PiJ/f0RmGGjgcNWyiN3B2Q==\"}}',',[Îü×BBD™uæXr–AŒÎ°3h•Ç±g\nÿƒôÙ','****',NULL,NULL,NULL,'2025-10-01 02:08:22.083314','2025-10-01 02:08:22.083314',1),
+(12,10,'passport','',NULL,'2020-03-15','2030-03-15',NULL,0,'{\"p\":\"/DmwMpjPX3Qcmw==\",\"h\":{\"iv\":\"eYeRep+Py/KXB7FM\",\"at\":\"NodC6l0Pbaby7SDx1QXbtg==\"}}','%AfMê×“¸x–Ûí`qV	‹M–B¬ì&QŸL¹.v±<','****',NULL,NULL,NULL,'2025-10-01 02:08:58.977107','2025-10-01 02:08:58.977107',4),
+(13,11,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"d2LZzS3M7+8G\",\"h\":{\"iv\":\"QRa59VZyrUPRCFvz\",\"at\":\"Ebv8JqjHkWYZ/LdeHtEY+g==\"}}','hïíÛ$CCh©@\'Š-Y)âü¤Á 2H¶;Ş¥','****',NULL,NULL,NULL,'2025-10-01 02:10:37.178904','2025-10-01 02:10:37.178904',1),
+(14,12,'ein','',NULL,NULL,NULL,NULL,1,'{\"p\":\"KimAjlNOkWCn\",\"h\":{\"iv\":\"Ydr6V1MwXJtd8XCq\",\"at\":\"lZbnk4+Ik/GcyyQCqJeoTg==\"}}','5›håµxwí,G(Ô»v¸€D¦²ÿaò`#¨œ','****',NULL,NULL,NULL,'2025-10-01 02:16:26.679168','2025-10-01 02:16:26.679168',2),
+(15,13,'ssn','',NULL,NULL,NULL,NULL,1,'{\"p\":\"+KC9gkAJgo9O\",\"h\":{\"iv\":\"S3If/DI4GSmWHyeO\",\"at\":\"hjWPQ20o5CTu4t4QLHp+dg==\"}}','/ĞŞÑçR÷ÅJÜQL†¸^ûéìò=n\"Øä\Z9OI','****',NULL,NULL,NULL,'2025-10-01 02:18:29.139032','2025-10-01 02:18:29.139032',1);
 /*!40000 ALTER TABLE `party_identifiers` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -354,7 +404,7 @@ CREATE TABLE `party_organizations` (
   KEY `index_party_organizations_on_party_id` (`party_id`),
   CONSTRAINT `fk_rails_1cd8c0c9ce` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`) ON DELETE CASCADE,
   CONSTRAINT `fk_rails_ad9f5a4e18` FOREIGN KEY (`organization_type_code`) REFERENCES `ref_organization_types` (`code`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=13 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -363,6 +413,8 @@ CREATE TABLE `party_organizations` (
 
 LOCK TABLES `party_organizations` WRITE;
 /*!40000 ALTER TABLE `party_organizations` DISABLE KEYS */;
+INSERT INTO `party_organizations` VALUES
+(12,'Cartwright PLC','llc','2002-07-14','2025-10-01 02:16:26.660759','2025-10-01 02:16:26.660759','');
 /*!40000 ALTER TABLE `party_organizations` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -386,7 +438,7 @@ CREATE TABLE `party_people` (
   PRIMARY KEY (`party_id`),
   KEY `index_party_people_on_party_id` (`party_id`),
   CONSTRAINT `fk_rails_7b5825ac1b` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=14 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -396,7 +448,18 @@ CREATE TABLE `party_people` (
 LOCK TABLES `party_people` WRITE;
 /*!40000 ALTER TABLE `party_people` DISABLE KEYS */;
 INSERT INTO `party_people` VALUES
-(1,'Steven','Jinks','1950-02-01','2025-09-30 05:04:29.988115','2025-09-30 05:04:29.988115','A','','Mr');
+(1,'Steven','Jinks','1950-02-01','2025-09-30 05:04:29.988115','2025-09-30 05:04:29.988115','A','','Mr'),
+(2,'Richard','Metzler','1959-01-24','2025-10-01 01:55:59.182181','2025-10-01 01:55:59.182181','M','','Mr'),
+(3,'John','Sanchez','1954-09-18','2025-10-01 01:58:00.112695','2025-10-01 01:58:00.112695','G','','Mr'),
+(4,'Keven','Waters','1990-07-24','2025-10-01 01:59:31.123681','2025-10-01 01:59:31.123681','E','','Mr'),
+(5,'Joanne','Clark','2004-04-21','2025-10-01 02:00:48.774644','2025-10-01 02:00:48.774644','E','','MS'),
+(6,'William','Gaines','1972-11-14','2025-10-01 02:02:09.642326','2025-10-01 02:02:09.642326','M','','Mr'),
+(7,'Linda','Hall','1951-10-09','2025-10-01 02:03:38.022850','2025-10-01 02:03:38.022850','K','','Ms'),
+(8,'Paula','Powers','1993-01-12','2025-10-01 02:05:01.174517','2025-10-01 02:05:01.174517','C','','Ms'),
+(9,'Estelle','Felt','1948-06-17','2025-10-01 02:06:28.766723','2025-10-01 02:06:28.766723','N','','Ms'),
+(10,'Julius','Berry','1983-05-10','2025-10-01 02:08:22.063480','2025-10-01 02:08:22.063480','E','','Mr'),
+(11,'Donald','Crown','1960-09-01','2025-10-01 02:10:37.153944','2025-10-01 02:10:37.153944','A','','Mr'),
+(13,'Amalia','Lazo','1985-08-15','2025-10-01 02:18:29.118093','2025-10-01 02:18:29.118093','R','','Ms');
 /*!40000 ALTER TABLE `party_people` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -423,7 +486,7 @@ CREATE TABLE `party_phones` (
   KEY `fk_rails_21d3746b66` (`phone_type_code`),
   CONSTRAINT `fk_rails_21d3746b66` FOREIGN KEY (`phone_type_code`) REFERENCES `ref_phone_types` (`code`),
   CONSTRAINT `fk_rails_b8177e2fac` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`) ON DELETE CASCADE
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -433,7 +496,20 @@ CREATE TABLE `party_phones` (
 LOCK TABLES `party_phones` WRITE;
 /*!40000 ALTER TABLE `party_phones` DISABLE KEYS */;
 INSERT INTO `party_phones` VALUES
-(1,1,'home','+15124276703',NULL,1,1,'2025-09-30 05:04:30.107060','2025-09-30 05:04:30.107060');
+(1,1,'home','+15124276703',NULL,1,1,'2025-09-30 05:04:30.107060','2025-09-30 05:04:30.107060'),
+(2,2,'home','+14053485631',NULL,1,0,'2025-10-01 01:55:59.219434','2025-10-01 01:55:59.219434'),
+(3,3,'home','+13615317475',NULL,1,0,'2025-10-01 01:58:00.151925','2025-10-01 01:58:00.151925'),
+(4,4,'mobile','+14126689693',NULL,1,1,'2025-10-01 01:59:31.144742','2025-10-01 01:59:31.144742'),
+(5,5,'mobile','+12143284948',NULL,1,1,'2025-10-01 02:00:48.807733','2025-10-01 02:00:48.807733'),
+(6,6,'mobile','+15086947271',NULL,1,1,'2025-10-01 02:02:09.658337','2025-10-01 02:02:09.658337'),
+(7,7,'mobile','+13156244655',NULL,1,1,'2025-10-01 02:03:38.057559','2025-10-01 02:03:38.057559'),
+(8,8,'mobile','+15164731349',NULL,1,1,'2025-10-01 02:05:01.186769','2025-10-01 02:12:12.198350'),
+(9,9,'home','+18162882553',NULL,1,0,'2025-10-01 02:06:28.787448','2025-10-01 02:06:28.787448'),
+(10,10,'mobile','+12163698001',NULL,1,1,'2025-10-01 02:08:22.081094','2025-10-01 02:08:22.081094'),
+(11,11,'mobile','+16072353984',NULL,1,1,'2025-10-01 02:10:37.173573','2025-10-01 02:10:37.173573'),
+(12,8,'home','+15169302211',NULL,0,0,'2025-10-01 02:11:58.026830','2025-10-01 02:12:03.349490'),
+(13,12,'work','+14066426522','127',1,0,'2025-10-01 02:16:26.676224','2025-10-01 02:16:26.676224'),
+(14,13,'work','+14066426522','127',1,0,'2025-10-01 02:18:29.134271','2025-10-01 02:18:29.134271');
 /*!40000 ALTER TABLE `party_phones` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -473,7 +549,7 @@ CREATE TABLE `party_screenings` (
   KEY `index_party_screenings_on_party_id` (`party_id`),
   CONSTRAINT `fk_rails_84457122a8` FOREIGN KEY (`party_id`) REFERENCES `parties` (`id`) ON DELETE CASCADE,
   CONSTRAINT `vendor_payload` CHECK (json_valid(`vendor_payload`))
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -482,6 +558,8 @@ CREATE TABLE `party_screenings` (
 
 LOCK TABLES `party_screenings` WRITE;
 /*!40000 ALTER TABLE `party_screenings` DISABLE KEYS */;
+INSERT INTO `party_screenings` VALUES
+(1,10,0,0,2,'Julius E Berry','1983-05-10','US','ssn','2207','2509302222',0.00,'2025-10-01 02:22:17.000000','2025-09-30 22:22:00.000000','2025-10-02 02:22:52.340911','{}','','2025-10-01 02:22:52.345120','2025-10-01 02:22:52.345120',NULL,NULL,NULL);
 /*!40000 ALTER TABLE `party_screenings` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -6227,4 +6305,4 @@ UNLOCK TABLES;
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2025-09-30 19:25:12
+-- Dump completed on 2025-10-01 14:16:44

--- a/db/migrate/20251001142832_add_len_and_last4_to_party_identifiers.rb
+++ b/db/migrate/20251001142832_add_len_and_last4_to_party_identifiers.rb
@@ -1,0 +1,7 @@
+# db/migrate/20251001000000_add_len_and_last4_to_party_identifiers.rb
+class AddLenAndLast4ToPartyIdentifiers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :party_identifiers, :value_len,   :integer
+    add_column :party_identifiers, :value_last4, :string, limit: 4
+  end
+end

--- a/db/migrate/20251001152921_update_identifier_type_mask_rules.rb
+++ b/db/migrate/20251001152921_update_identifier_type_mask_rules.rb
@@ -1,0 +1,26 @@
+class UpdateIdentifierTypeMaskRules < ActiveRecord::Migration[7.2]
+  def up
+    Ref::IdentifierType.where(code: 'ssn')
+      .update_all(mask_rule: 'ssn', sort_order: 100)
+
+    Ref::IdentifierType.where(code: 'ein')
+      .update_all(mask_rule: 'ein', sort_order: 120)
+
+    Ref::IdentifierType.where(code: %w[tin itin])
+      .update_all(mask_rule: 'ssn', sort_order: 140)
+
+    Ref::IdentifierType.where(code: 'passport')
+      .update_all(mask_rule: 'first1_last4', sort_order: 200,
+                  require_issuer_country: true)
+
+    Ref::IdentifierType.where(code: 'dl')
+      .update_all(mask_rule: 'first1_last4', sort_order: 220,
+                  require_issuer_country: true, require_issuer_region: true)
+  end
+
+  def down
+    Ref::IdentifierType.where(code: %w[ssn ein tin itin passport dl])
+      .update_all(mask_rule: nil, sort_order: nil,
+                  require_issuer_country: false, require_issuer_region: false)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_09_30_160022) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_01_152921) do
   create_table "customer_number_counters", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "current_value", null: false
     t.integer "min_value", default: 1001, null: false
@@ -104,6 +104,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_09_30_160022) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "identifier_type_id"
+    t.integer "value_len"
+    t.string "value_last4", limit: 4
     t.index ["id_type_code", "value_bidx"], name: "idx_unique_identifier_value", unique: true
     t.index ["identifier_type_id", "value_bidx"], name: "idx_unique_identifier_type_value", unique: true
     t.index ["identifier_type_id"], name: "index_party_identifiers_on_identifier_type_id"

--- a/docs/adrs/0030-adr-identifier-masking-derived-len-last4.md
+++ b/docs/adrs/0030-adr-identifier-masking-derived-len-last4.md
@@ -1,0 +1,33 @@
+# ADR 0030: Identifier masking derives from length + last4, not stored mask
+
+**Status**: Accepted  
+**Date**: 2025-10-01
+
+## Context
+`party_identifiers.value_masked` stored asterisks. After encryption refactor, masked output drifted and sometimes showed only masks.
+
+## Decision
+Do not persist masked strings. Persist only:
+- `value_len : integer`
+- `value_last4 : varchar(4)`
+
+Render masks at view/model time.
+
+## Consequences
+- No decrypt at render for masking.
+- Eliminates drift and simplifies key rotation.
+- Single callback derives fields on write/update.
+
+## Implementation
+- Migration: add `value_len`, `value_last4`; backfill from decrypted `value`.
+- Model: `before_validation :derive_len_last4`; helpers `masked`, `masked_formatted`.
+- Temporary shim: `def value_masked = masked_formatted`.
+
+## Security
+- Less derived PII stored. Logs/exports show only length and last4.
+
+## Rollout
+1) Ship migration and backfill.  
+2) Deploy model changes.  
+3) Update views to `masked_formatted`.  
+4) Later: drop `value_masked`.

--- a/docs/adrs/0031-adr-mask-rules-data-driven.md
+++ b/docs/adrs/0031-adr-mask-rules-data-driven.md
@@ -1,0 +1,35 @@
+# ADR 0031: Mask rules are data-driven via `ref_identifier_types.mask_rule`
+
+**Status**: Accepted  
+**Date**: 2025-10-01
+
+## Context
+Masking logic was hardcoded. Adding new identifier types required code edits.
+
+## Decision
+Drive display rules from `ref_identifier_types.mask_rule`.
+
+Allowed values:
+- `ssn` → `***-**-last4` when length==9  
+- `ein` → last4 only (no prefix disclosure)  
+- `last4` → generic last4  
+- `first1_last4` → passport/DL policy  
+- `pattern:x-y-z` → grouping template  
+- `none` → render nothing
+
+## Consequences
+- New types configured without deploys.
+- Policy centralized and auditable.
+
+## Implementation
+- Model validator allows values above.
+- `Identifier#masked_formatted` branches on `identifier_type.mask_rule`.
+- Data migration sets rules and `sort_order` for existing types.
+
+## Security
+- Prevents accidental overexposure; easy to audit/modify.
+
+## Rollout
+1) Validator + formatting method.  
+2) Data migration to set rules and flags.  
+3) Verify views call `masked_formatted`.

--- a/docs/adrs/0032-adr-identifier-display-policy-and-issuer-requirements.md
+++ b/docs/adrs/0032-adr-identifier-display-policy-and-issuer-requirements.md
@@ -1,0 +1,29 @@
+# ADR 0032: EIN/SSN/TIN/Passport/DL display policy and issuer requirements
+
+**Status**: Accepted  
+**Date**: 2025-10-01
+
+## Context
+Different identifiers require distinct disclosure and issuer metadata.
+
+## Decision
+- **SSN/ITIN/TIN**: show `***-**-last4` when `value_len==9`. Sort 100 (SSN), 140 (TIN/ITIN).
+- **EIN**: show last4 only; no prefix. Sort 120.
+- **Passport**: `first1_last4`; require issuer country. Sort 200.
+- **Driver license**: `first1_last4`; require issuer country and region. Sort 220.
+
+## Consequences
+- Consistent UX.  
+- Completes compliance metadata capture.
+
+## Implementation
+- Data migration updates `mask_rule`, `sort_order`, `require_issuer_country`, `require_issuer_region`.
+- Model validation `issuer_requirements` enforces flags at save.
+
+## Security
+- Least-disclosure principle for identifiers.
+
+## Rollout
+- Apply migration.  
+- QA renders per type.  
+- Update seeds/fixtures accordingly.

--- a/docs/adrs/0033-adr-deprecate-value-masked-column.md 
+++ b/docs/adrs/0033-adr-deprecate-value-masked-column.md 
@@ -1,0 +1,21 @@
+# ADR 0033: Deprecate `value_masked` column
+
+**Status**: Proposed  
+**Date**: 2025-10-01
+
+## Context
+`value_masked` exists but is no longer authoritative after ADR 0030.
+
+## Decision
+Keep short-term for compatibility. Remove after all consumers use `masked_formatted`.
+
+## Consequences
+- Temporary redundancy only during transition.
+
+## Implementation
+- Method shim: `def value_masked = masked_formatted`.
+- Follow-up migration to drop column after verification.
+
+## Rollout
+- Search usages and update.  
+- Remove within one release cycle post-cutover.

--- a/script/sqldump.sh
+++ b/script/sqldump.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo mysqldump bankencorre_development < /home/syckot/bankencore/betest/bankencorre.sql


### PR DESCRIPTION
**Title:** Identifier masking refactor: derive from length+last4, data-driven rules; migrate mask rules; tighten issuer requirements

**Summary**

* Stop persisting masked strings. Store `value_len` and `value_last4`. Render masks at view/model layer.
* Drive display via `ref_identifier_types.mask_rule`.
* Set mask rules + sort order for SSN/EIN/TIN/Passport/DL. Enforce issuer flags where required.
* Maintain temporary shim `value_masked = masked_formatted`.

**Scope of changes**

* Model: `Party::Identifier`

  * `before_validation :derive_len_last4`
  * Helpers: `masked`, `masked_formatted`
  * Remove `before_save :set_mask`
  * Keep validations and uniqueness checks
* Model: `Ref::IdentifierType`

  * Validator for `mask_rule` including `pattern:x-y-z` and `first1_last4`
  * Uniqueness on `code`
* Views

  * Replace usages of persisted `value_masked` with `masked_formatted` (display) and `masked` (data attributes)
* Data

  * Migration to add `value_len`, `value_last4` and backfill
  * Migration to set `mask_rule`, `sort_order`, issuer flags

**Migrations**

* Add columns: `party_identifiers.value_len:int`, `party_identifiers.value_last4:varchar(4)`
* Backfill existing identifiers from decrypted `value`
* Update `ref_identifier_types`:

  * `ssn` → `mask_rule='ssn'`, `sort_order=100`
  * `ein` → `mask_rule='ein'`, `sort_order=120`
  * `tin/itin` → `mask_rule='ssn'`, `sort_order=140`
  * `passport` → `mask_rule='first1_last4'`, `sort_order=200`, `require_issuer_country=1`
  * `dl` → `mask_rule='first1_last4'`, `sort_order=220`, `require_issuer_country=1`, `require_issuer_region=1`

**Security/PII**

* Reduces stored derived PII. No decrypt needed at render for masking. Centralizes disclosure policy.

**Testing**

* Unit:

  * `Identifier#derive_len_last4` for varied inputs and types
  * `masked` and `masked_formatted` output for SSN/EIN/TIN/Passport/DL, including edge lengths <4 and non-digit characters
  * `issuer_requirements` validation paths
* Integration:

  * Party `#show` renders `***-**-1234` for SSN when `value_len==9`
  * EIN renders last4 only
  * Data attributes use `masked`
* Data migration dry run in staging. Verify updated `ref_identifier_types` rows and sample identifier renders.

**Backward compatibility**

* Temporary shim: `def value_masked = masked_formatted`
* No API surface changes

**Risk**

* Missed view call sites still referencing persisted `value_masked`
* Inconsistent `mask_rule` values in ref data

**Mitigation**

* Grep for `value_masked` and replace
* Seed/migration enforces allowed `mask_rule` values
* Add DB check: `value_len >= 0` (optional)

**Rollback plan**

* Revert migrations and models
* `value_masked` remains populated for historical rows
* No data loss in source `value`

**Related ADRs**

* ADR 0030: Identifier masking derives from length + last4
* ADR 0031: Data-driven mask rules
* ADR 0032: Display policy and issuer requirements
* ADR 0033: Deprecate `value_masked` column
