### PR TITLE
Expose route helpers globally to fix missing ref_regions_path in views

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,6 +5,8 @@ class ApplicationController < ActionController::Base
 
   helper_method :current_user, :authenticated?
 
+  helper Rails.application.routes.url_helpers
+
   def current_user
     Current.user            # Authentication concern populates Current.session → Current.user
   end


### PR DESCRIPTION
A `NoMethodError` occurred in `party/identifiers/_fields.html.erb` when calling `ref_regions_path`.
Although the route was defined under `namespace :ref`, the helper was unavailable in that view context.
This change updates `ApplicationController` to include `Rails.application.routes.url_helpers`, making all path helpers accessible across views and components.

**Summary of changes:**

* Updated `app/controllers/application_controller.rb` to include route helpers
* Verified `ref_regions_path` now resolves correctly in partials
* No functional or schema changes beyond helper exposure
