### PR TITLE
**feat(party/person): add citizenship, nationality, residence with re…

### DIFF
--- a/app/controllers/party/parties_controller.rb
+++ b/app/controllers/party/parties_controller.rb
@@ -123,6 +123,7 @@ module Party
       @party.addresses.build(country_code: "US") if @party.addresses.empty?
       @party.emails.build                         if @party.emails.empty?
       @party.phones.build(country_alpha2: "US")   if @party.phones.empty?
+      @countries = Ref::Country.order(:name)
     end
 
     def edit
@@ -131,6 +132,7 @@ module Party
       @party.addresses.build(country_code: "US") if @party.addresses.empty?
       @party.emails.build                         if @party.emails.empty?
       @party.phones.build(country_alpha2: "US")   if @party.phones.empty?
+      @countries = Ref::Country.order(:name)
     end
 
     def create
@@ -216,7 +218,7 @@ module Party
     def party_params
       params.require(:party_party).permit(
         :party_type,
-        person_attributes: [ :id, :first_name, :middle_name, :last_name, :name_suffix, :courtesy_title, :date_of_birth, :_destroy ],
+        person_attributes: [ :id, :first_name, :middle_name, :last_name, :name_suffix, :courtesy_title, :date_of_birth, :citizenship, :nationality_country_code, :residence_country_code, :_destroy ],
         organization_attributes: [ :id, :legal_name, :operating_name, :organization_type_code, :formation_date, :_destroy ],
         addresses_attributes: [ :id, :address_type_code, :line1, :line2, :line3, :locality, :region_code, :postal_code, :country_code, :is_primary, :_destroy ],
         emails_attributes: [ :id, :email, :email_type_code, :is_primary, :_destroy ],
@@ -228,7 +230,7 @@ module Party
     def load_ref_options
       @address_types    = Ref::AddressType.order(:name)
       @countries        = Ref::Country.order(:name)
-      @org_types        = Ref::OrganizationType.order(:name)
+      @org_types        = Ref::OrganizationType.order(:name).to_a
       @email_types      = Ref::EmailType.order(:name)
       @phone_types      = Ref::PhoneType.order(:name)
       @identifier_types = Ref::IdentifierType.order(:sort_order, :name)

--- a/app/javascript/controllers/_index._js_old
+++ b/app/javascript/controllers/_index._js_old
@@ -31,3 +31,6 @@ application.register("party-target-picker", PartyTargetPickerController)
 
 import IdentifierRowController from "./identifier_row_controller"
 application.register("identifier-row", IdentifierRowController)
+
+import ToggleController from "./toggle_controller.js";
+application.register("toggle", ToggleController);

--- a/app/javascript/controllers/toggle_controller.js
+++ b/app/javascript/controllers/toggle_controller.js
@@ -1,0 +1,14 @@
+import { Controller } from "@hotwired/stimulus";
+
+export default class extends Controller {
+  connect() { this.refresh(); }
+
+  refresh() {
+    // name Rails generates for nested attr: party_party[person][citizenship]
+    const form = this.element.closest("form");
+    const input = form?.querySelector('input[name="party_party[person][citizenship]"]:checked');
+    const value = input?.value; // "domestic" or "foreign"
+    const hide = (value === "domestic"); // hide nationality when domestic
+    this.element.classList.toggle("hidden", hide);
+  }
+}

--- a/app/models/party/party.rb
+++ b/app/models/party/party.rb
@@ -57,6 +57,10 @@ module Party
           %w[value id_type_code country_code issuing_authority issued_on expires_on is_primary].all? { |k| h[k].to_s.strip.blank? }
       }
 
+    after_initialize do
+      build_person if new_record? && person.nil?
+    end
+
     # Virtuals for simple form binding
     attr_accessor :tax_id_input, :tax_id_type  # "ssn","ein","itin","foreign_tin"
     before_save :sync_tax_identifier_from_virtual

--- a/app/models/party/person.rb
+++ b/app/models/party/person.rb
@@ -3,10 +3,35 @@ module Party
     self.primary_key = "party_id"
     self.table_name = "party_people"
 
+    enum :citizenship, { domestic: 0, foreign: 1 }
+
     belongs_to :party, class_name: "Party::Party", foreign_key: :party_id
+    belongs_to :nationality_country,
+      class_name: "Ref::Country",
+      foreign_key: :nationality_country_code,
+      primary_key: :code,
+      optional: true
+    belongs_to :residence_country,
+      class_name: "Ref::Country",
+      foreign_key: :residence_country_code,
+      primary_key: :code,
+      optional: false
+
+    before_validation :apply_defaults_and_rules
 
     # optional validations:
     validates :first_name, presence: true
     validates :last_name, presence: true
+
+    validates :residence_country_code, presence: true
+    validates :nationality_country_code, presence: true, if: -> { foreign? }
+
+    private
+    def apply_defaults_and_rules
+      self.residence_country_code ||= "US"
+      if domestic?
+        self.nationality_country_code = "US"
+      end
+    end
   end
 end

--- a/app/views/party/parties/_form.html.erb
+++ b/app/views/party/parties/_form.html.erb
@@ -47,6 +47,7 @@
             <%= pf.hidden_field :_destroy,
                   value: (@party.party_type=='person' ? "0" : "1"),
                   data: { party_type_target: "personDestroy" } %>
+
             <div class="grid grid-cols-12 gap-4">
               <div class="col-span-12 md:col-span-3">
                 <label class="label-text mb-1 block">Title</label>
@@ -71,6 +72,32 @@
               <div class="col-span-12 md:col-span-3">
                 <label class="label-text mb-1 block">Date of birth</label>
                 <%= pf.date_field :date_of_birth, class:"input input-bordered w-full", autocomplete:"bday" %>
+              </div>
+
+              <%# ---- Citizenship / Nationality / Residence ---- %>
+              <div class="col-span-12 md:col-span-6">
+                <label class="label-text mb-1 block">Citizenship</label>
+                <div class="join">
+                  <label class="btn">
+                    <%= pf.radio_button :citizenship, :domestic, data: { action: "change->toggle#refresh" } %> Domestic
+                  </label>
+                  <label class="btn">
+                    <%= pf.radio_button :citizenship, :foreign,  data: { action: "change->toggle#refresh" } %> Foreign
+                  </label>
+                </div>
+              </div>
+
+              <div class="col-span-12 md:col-span-6 <%= 'hidden' if pf.object.domestic? %>"
+                  data-controller="toggle">
+                <label class="label-text mb-1 block">Nationality</label>
+                <%= pf.collection_select :nationality_country_code, @countries, :code, :name,
+                      { include_blank: true }, class: "select select-bordered w-full" %>
+              </div>
+
+              <div class="col-span-12 md:col-span-6">
+                <label class="label-text mb-1 block">Country of residence</label>
+                <%= pf.collection_select :residence_country_code, @countries, :code, :name,
+                      {}, class: "select select-bordered w-full" %>
               </div>
             </div>
           <% end %>
@@ -120,7 +147,6 @@
             </summary>
 
             <div class="pt-3">
-
               <ul role="list" class="space-y-3">
                 <%= f.fields_for :identifiers do |idf| %>
                   <%= render "party/identifiers/fields",

--- a/db/migrate/20251011203635_add_citizenship_fields_to_party_people.rb
+++ b/db/migrate/20251011203635_add_citizenship_fields_to_party_people.rb
@@ -1,0 +1,23 @@
+class AddCitizenshipFieldsToPartyPeople < ActiveRecord::Migration[7.2]
+  def change
+    add_column :party_people, :citizenship, :integer, null: false, default: 0  # 0=domestic, 1=foreign
+    add_column :party_people, :nationality_country_code, :string, limit: 2
+    add_column :party_people, :residence_country_code,   :string, limit: 2, null: false, default: "US"
+
+    add_index :party_people, :citizenship
+    add_index :party_people, :nationality_country_code
+    add_index :party_people, :residence_country_code
+
+    add_foreign_key :party_people, :ref_countries, column: :nationality_country_code, primary_key: :code
+    add_foreign_key :party_people, :ref_countries, column: :residence_country_code,   primary_key: :code
+
+    # Guardrails
+    add_check_constraint :party_people,
+      "(citizenship = 0 AND (nationality_country_code IS NULL OR nationality_country_code = 'US')) OR (citizenship = 1 AND nationality_country_code IS NOT NULL AND nationality_country_code <> 'US')",
+      name: "chk_people_citizenship_nationality"
+
+    add_check_constraint :party_people,
+      "residence_country_code IS NOT NULL",
+      name: "chk_people_residence_present"
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_10_08_204117) do
+ActiveRecord::Schema[8.0].define(version: 2025_10_11_203635) do
   create_table "customer_number_counters", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
     t.integer "current_value", null: false
     t.integer "min_value", default: 1001, null: false
@@ -202,7 +202,15 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_204117) do
     t.string "middle_name"
     t.string "name_suffix"
     t.string "courtesy_title"
+    t.integer "citizenship", default: 0, null: false
+    t.string "nationality_country_code", limit: 2
+    t.string "residence_country_code", limit: 2, default: "US", null: false
+    t.index ["citizenship"], name: "index_party_people_on_citizenship"
+    t.index ["nationality_country_code"], name: "index_party_people_on_nationality_country_code"
     t.index ["party_id"], name: "index_party_people_on_party_id"
+    t.index ["residence_country_code"], name: "index_party_people_on_residence_country_code"
+    t.check_constraint "`citizenship` = 0 and (`nationality_country_code` is null or `nationality_country_code` = 'US') or `citizenship` = 1 and `nationality_country_code` is not null and `nationality_country_code` <> 'US'", name: "chk_people_citizenship_nationality"
+    t.check_constraint "`residence_country_code` is not null", name: "chk_people_residence_present"
   end
 
   create_table "party_phones", charset: "utf8mb4", collation: "utf8mb4_general_ci", force: :cascade do |t|
@@ -379,6 +387,8 @@ ActiveRecord::Schema[8.0].define(version: 2025_10_08_204117) do
   add_foreign_key "party_organizations", "parties", on_delete: :cascade
   add_foreign_key "party_organizations", "ref_organization_types", column: "organization_type_code", primary_key: "code"
   add_foreign_key "party_people", "parties", on_delete: :cascade
+  add_foreign_key "party_people", "ref_countries", column: "nationality_country_code", primary_key: "code"
+  add_foreign_key "party_people", "ref_countries", column: "residence_country_code", primary_key: "code"
   add_foreign_key "party_phones", "parties", on_delete: :cascade
   add_foreign_key "party_phones", "ref_phone_types", column: "phone_type_code", primary_key: "code"
   add_foreign_key "party_screenings", "parties", on_delete: :cascade


### PR DESCRIPTION
…active UI**

* Add fields to `party_people`: `citizenship:int (0=domestic,1=foreign)`, `nationality_country_code`, `residence_country_code` (default `US`).
* Model: `enum :citizenship`, defaults, and rules → domestic forces nationality `US`; foreign requires nationality.
* Strong params: permit `person_attributes[:citizenship, :nationality_country_code, :residence_country_code]`.
* Views: bind person fields via `fields_for :person`; add radio inputs for citizenship; nationality select shown only when foreign; residence select always shown.
* Stimulus: `toggle` controller to show/hide nationality on radio change.
* Controller: preload `@countries`; ensure `@party.build_person` for new/edit.
* Remove stray party-level `f.*` nationality/residence fields.

**Migration**
`AddCitizenshipFieldsToPartyPeople`

* Columns and indexes for the three fields.
* FKs to `ref_countries` on `nationality_country_code` and `residence_country_code`.
* Optional: check constraints to enforce domestic→US nationality and foreign→non-US nationality.

**Why**

* KYC capture of citizenship, nationality, and residence.
* Deterministic defaults: residence `US`; domestic implies nationality `US`.

**Deploy notes**

1. Run migration.
2. Precompile JS so `toggle_controller` loads.
3. Verify forms for existing people; nationality should be hidden when citizenship is domestic.

**Tests / QA**

* New person defaults to domestic, nationality hidden, residence prefilled `US`.
* Switch to foreign → nationality select appears and is required.
* Persist and reload shows correct values and toggle state.

<!-- Keep PRs small and focused. Link issues. Use clear, factual language. -->

## Summary
Briefly state what this PR does and why.

## Type
- [ ] feat
- [ ] fix
- [ ] chore
- [ ] docs
- [ ] refactor
- [ ] test
- [ ] perf
- [ ] ci

## Context
- Issue: Closes #____
- Background: What led to this change?

## Changes
- Bullet the notable changes
- Mention user-facing behavior

## Screenshots / Demos (optional)
<!-- Before/after images or GIF. -->

## Database / Migrations
- [ ] No schema changes
- [ ] Includes migration(s): `xxxx_add_yyy.rb`
- [ ] Backfill or data migration plan noted

## Security
- [ ] No new sensitive data stored or logged
- [ ] AuthZ/AuthN impacts reviewed
- [ ] Secrets untouched

## Performance
- [ ] No significant impact
- [ ] Benchmarks or reasoning included

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual QA steps documented below

Manual QA steps
